### PR TITLE
Fix/admin seats unavailable

### DIFF
--- a/ShipsCinema/Datamodels/Seat.cs
+++ b/ShipsCinema/Datamodels/Seat.cs
@@ -6,6 +6,7 @@ public class Seat
     public int UserId;
     public bool IsSeat;
     public bool IsAvailable;
+    public bool IsReserved;
 
     public Seat(int row, int column, double price, int userId, bool isSeat, bool isAvailable)
     {

--- a/ShipsCinema/Logic/AdminHandler.cs
+++ b/ShipsCinema/Logic/AdminHandler.cs
@@ -316,9 +316,9 @@ public static class AdminHandler
         if (show == null)
             return;
 
-        Theater theater = TheaterHandler.CreateTheater(show);
+        Theater theater = TheaterHandler.CreateOrGetTheater(show);
 
-        TheaterHandler.SelectSeats(adminAccount, theater, null);
+        TheaterHandler.SelectSeats(adminAccount, theater);
     }
 
     public static int GetHighestID()

--- a/ShipsCinema/Logic/CheckOutHandler.cs
+++ b/ShipsCinema/Logic/CheckOutHandler.cs
@@ -145,7 +145,7 @@ public class CheckOutHandler
         JSONMethods.WriteToJSON(revenues, FileName);
     }
 
-    public static void CheckOut()
+    public static bool CheckOut()
     {
         bool checkOut = true;
         bool confirm = false;
@@ -259,7 +259,7 @@ public class CheckOutHandler
                     Console.WriteLine("Press any button to continue");
                     Console.ReadKey();
                     Console.Clear();
-                    return;
+                    return true;
                 }
                 else if (pressedKey == ConsoleKey.N)
                 {
@@ -268,5 +268,7 @@ public class CheckOutHandler
                 }
             }
         }
+
+        return false;
     }
 }

--- a/ShipsCinema/Logic/MovieHandler.cs
+++ b/ShipsCinema/Logic/MovieHandler.cs
@@ -23,7 +23,7 @@ public static class MovieHandler
     {
         Console.WriteLine($"{movie.Title}");
         Console.WriteLine($"\nDescription:\n{movie.Description}");
-        Console.Write("Genres: ");
+        Console.Write("\nGenres: ");
         Console.Write(string.Join(", ", movie.Genres));
         Console.WriteLine($"\nLanguage: {movie.Language}");
         Console.WriteLine($"Runtime: {movie.Runtime} Minutes");

--- a/ShipsCinema/Logic/ReservationHandler.cs
+++ b/ShipsCinema/Logic/ReservationHandler.cs
@@ -170,7 +170,7 @@ public static class ReservationHandler
                 $"\nThese are your tickets for reservation {overviewCorrectReservation[selectedReservation]}:\n"
             );
             int reservationInt = 1;
-            Console.WriteLine("Ticket No. | Row | Seat");
+            Console.WriteLine("Ticket No. | Row    | Seat");
             Console.WriteLine(new string('-', 28));
 
             foreach (var reservation in reservationsUser)
@@ -189,11 +189,14 @@ public static class ReservationHandler
         // Hier heb je geen reservations
         else
         {
-            Console.WriteLine("You currently have no reservations.");
+            Console.Clear();
+            DisplayAsciiArt.Header();
+            AdHandler.DisplaySnacks();
+            Console.WriteLine("Reservations\n\nYou currently have no reservations.");
         }
 
         Console.ForegroundColor = ConsoleColor.DarkGray;
-        Console.WriteLine("Press any key to go back");
+        Console.WriteLine("\nPress any key to go back");
         Console.ReadKey();
         Console.ResetColor();
     }

--- a/ShipsCinema/Logic/ShowHandler.cs
+++ b/ShipsCinema/Logic/ShowHandler.cs
@@ -489,7 +489,7 @@ public static class ShowHandler
         foreach (var day in showsFilteredGrouped)
         {
             date = day.First().DateAndTime;
-            Console.WriteLine($"{date.DayOfWeek}, {date.ToString("MMMM", englishCulture)} {date.Day}, {date:yyyy}");
+            Console.WriteLine($"{date.DayOfWeek} {date.Day} {date.ToString("MMMM", englishCulture)} {date:yyyy}");
 
             foreach (var show in day)
             {

--- a/ShipsCinema/Logic/ShowHandler.cs
+++ b/ShipsCinema/Logic/ShowHandler.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualBasic;
+using System.Globalization;
 
 public static class ShowHandler
 {
@@ -470,6 +471,7 @@ public static class ShowHandler
 
     public static void PrintMovieDates(Movie movie, bool isAdmin = false)
     {
+        CultureInfo englishCulture = new CultureInfo("en-US");
         Console.Clear();
 
         var shows = JSONMethods.ReadJSON<Show>(FileName).Where(s => s.DateAndTime >= DateTime.Now);
@@ -487,7 +489,8 @@ public static class ShowHandler
         foreach (var day in showsFilteredGrouped)
         {
             date = day.First().DateAndTime;
-            Console.WriteLine($"{date.DayOfWeek} {date:D}");
+            Console.WriteLine($"{date.DayOfWeek}, {date.ToString("MMMM", englishCulture)} {date.Day}, {date:yyyy}");
+
             foreach (var show in day)
             {
                 Console.WriteLine($"  {show.StartTimeString} - Auditorium {show.TheaterNumber}");

--- a/ShipsCinema/Logic/TheaterHandler.cs
+++ b/ShipsCinema/Logic/TheaterHandler.cs
@@ -107,7 +107,7 @@ public static class TheaterHandler
                     //Seat selectedSeat = GetSeatByRowAndColumn(theater, selectedRow, selectedColumn)!;
 
                     // Deselect seat
-                    if (selectedSeats.Contains(selectedSeat))
+                    if (selectedSeats.Contains(selectedSeat) || user.IsAdmin && !selectedSeat.IsReserved && !selectedSeat.IsAvailable)
                     {
                         selectedSeat.IsAvailable = true;
                         selectedSeat.UserId = -1;

--- a/ShipsCinema/Presentation/Program.cs
+++ b/ShipsCinema/Presentation/Program.cs
@@ -65,15 +65,8 @@ public class Program
                         if (selectedShow is null)
                             continue;
 
-                        var theater = TheaterHandler.CreateTheater(selectedShow);
-
-                        string ReservationId = ReservationHandler.GetReservationID();
-
-                        List<Ticket>? tickets = TheaterHandler.SelectSeats(loggedInUser, theater, ReservationId);
-                        if (tickets is null)
-                            continue;
-
-                        CheckOutHandler.CheckOut();
+                        var theater = TheaterHandler.CreateOrGetTheater(selectedShow);
+                        TheaterHandler.SelectSeats(loggedInUser, theater);
                         break;
                     case 2:
                         Console.Clear();


### PR DESCRIPTION
Making unavailable of seats for admin is now improved. You can now make seats available that you made unavailable during a previous login session.

Changed the date string that gets displayed to the user when going to Movies -> Selected a movie -> Display Showings