### PR TITLE
Fix/credit card date validator

### DIFF
--- a/ShipsCinema/Logic/CheckOutHandler.cs
+++ b/ShipsCinema/Logic/CheckOutHandler.cs
@@ -228,11 +228,13 @@ public class CheckOutHandler
         WriteHeaders();
         WriteBookingInfo(movie, show, seatsInfo);
         Console.WriteLine($"\n\nIs this information correct?\n[Y] Yes, continue to checkout\n[N] No, go back to seat selection\n");
-        ConsoleKey pressedKey = Console.ReadKey().Key;
-        if (pressedKey == ConsoleKey.Y)
-            return true;
-        
-        return false;
+        ConsoleKey pressedKey = Console.ReadKey(true).Key;
+        while (pressedKey != ConsoleKey.Y && pressedKey != ConsoleKey.N)
+        {
+            pressedKey = Console.ReadKey(true).Key;
+        }
+
+        return pressedKey == ConsoleKey.Y ? true : false;
     }
     
     public static (bool bookingCorrect, bool paymentConfirmed) CheckOut(Show selectedShow, List<Seat> seats)

--- a/ShipsCinema/Logic/FinancialHandler.cs
+++ b/ShipsCinema/Logic/FinancialHandler.cs
@@ -3,6 +3,7 @@
     public static List<string> GetYears()
     {
         // TO BE IMPLEMENTED
-        return new List<string> { "2022", "2023" };
+
+        return new List<string> { "2024" };
     }
 }

--- a/ShipsCinema/Validators/ValidateExpirationDate.cs
+++ b/ShipsCinema/Validators/ValidateExpirationDate.cs
@@ -13,7 +13,7 @@
 
         if (dateParts.Length == 2 && int.TryParse(dateParts[0], out int month) && int.TryParse(dateParts[1], out int year))
         {
-            if (month > 12)
+            if (month > 12 || month < 1 || year < 1 || year > 99)
                 return (false, false);
             DateTime parsedExpirationDate = new DateTime(2000 + year, month, 1).AddMonths(1).AddDays(-1);
             DateTime currentDate = DateTime.Now;

--- a/ShipsCinema/Validators/ValidateExpirationDate.cs
+++ b/ShipsCinema/Validators/ValidateExpirationDate.cs
@@ -13,6 +13,8 @@
 
         if (dateParts.Length == 2 && int.TryParse(dateParts[0], out int month) && int.TryParse(dateParts[1], out int year))
         {
+            if (month > 12)
+                return (false, false);
             DateTime parsedExpirationDate = new DateTime(2000 + year, month, 1).AddMonths(1).AddDays(-1);
             DateTime currentDate = DateTime.Now;
 


### PR DESCRIPTION
Fixes:
- Credit card date validator no longer crashes if a too high number is entered for the month (e.g. 23/26).
- Confirming booking information now only accepts Y or N as key inputs. Before it confirm with Y and allow any other key to cancel.