### PR TITLE
Fix/null reference for theater

### DIFF
--- a/ShipsCinema/Logic/ShowHandler.cs
+++ b/ShipsCinema/Logic/ShowHandler.cs
@@ -134,6 +134,7 @@ public static class ShowHandler
             
             Shows.Add(show);
             JSONMethods.WriteToJSON(Shows, FileName);
+            TheaterHandler.CreateOrGetTheater(show);
             
             Console.Clear();
             DisplayAsciiArt.AdminHeader();

--- a/ShipsCinema/Logic/ShowHandler.cs
+++ b/ShipsCinema/Logic/ShowHandler.cs
@@ -510,9 +510,7 @@ public static class ShowHandler
                 Show selectedShow = shows[index];
                 Theater? theater = TheaterHandler.GetTheaterByShowId(selectedShow.Id);
                 if (theater == null)
-                {
                     theater = TheaterHandler.CreateOrGetTheater(selectedShow);
-                }
 
                 if (user != null)
                     TheaterHandler.SelectSeats(user, theater);

--- a/ShipsCinema/Logic/ShowHandler.cs
+++ b/ShipsCinema/Logic/ShowHandler.cs
@@ -507,7 +507,12 @@ public static class ShowHandler
             else
             {
                 Show selectedShow = shows[index];
-                Theater theater = TheaterHandler.GetTheaterByShowId(selectedShow.Id)!;
+                Theater? theater = TheaterHandler.GetTheaterByShowId(selectedShow.Id);
+                if (theater == null)
+                {
+                    theater = TheaterHandler.CreateOrGetTheater(selectedShow);
+                }
+
                 if (user != null)
                     TheaterHandler.SelectSeats(user, theater);
                 return;

--- a/ShipsCinema/Logic/TheaterHandler.cs
+++ b/ShipsCinema/Logic/TheaterHandler.cs
@@ -97,7 +97,9 @@ public static class TheaterHandler
             if (!user.IsAdmin)
             {
                 totalPrice = TicketHandler.GetTotalPrice(tickets);
-                Console.WriteLine($"Total price of reservation: {totalPrice} EUR\n");
+                Console.Write($"Total price of reservation: ");
+                Console.ForegroundColor = ConsoleColor.Magenta;
+                Console.Write(totalPrice + " EUR\n");
             }
 
             WriteControlsInfo(user);
@@ -353,7 +355,14 @@ public static class TheaterHandler
             Console.Write("\nO: Your seat(s) from previous reservations\n");
 
             Console.ResetColor();
-            Console.WriteLine($"Current seat: {selectedSeat}\n");
+            Console.Write($"Current seat: Row ");
+            Console.ForegroundColor= ConsoleColor.Magenta;
+            Console.Write($"[{selectedSeat.Row + 1}]");
+            Console.ResetColor();
+            Console.Write($", Seat ");
+            Console.ForegroundColor = ConsoleColor.Magenta;
+            Console.Write($"[{selectedSeat.Column + 1}]\n");
+            Console.ResetColor();
         }
         else
         {

--- a/ShipsCinema/Logic/TheaterHandler.cs
+++ b/ShipsCinema/Logic/TheaterHandler.cs
@@ -42,7 +42,7 @@ public static class TheaterHandler
     }
 
     public static void SelectSeats(User user, Theater theater)
-    {   
+    {
         foreach (var seat in theater.Seats)
             if (!seat.IsReserved)
                 seat.UserId = -1;

--- a/ShipsCinema/Logic/TheaterHandler.cs
+++ b/ShipsCinema/Logic/TheaterHandler.cs
@@ -42,7 +42,7 @@ public static class TheaterHandler
     }
 
     public static void SelectSeats(User user, Theater theater)
-    {
+    {   
         foreach (var seat in theater.Seats)
             if (!seat.IsReserved)
                 seat.UserId = -1;

--- a/ShipsCinema/Presentation/DisplayAsciiArt.cs
+++ b/ShipsCinema/Presentation/DisplayAsciiArt.cs
@@ -6,7 +6,7 @@
     {
         FadeInEffect(AsciiArt.logo);
 
-        Thread.Sleep(2600);
+        Thread.Sleep(1800);
         Console.Clear();
     }
 

--- a/ShipsCinema/Presentation/Program.cs
+++ b/ShipsCinema/Presentation/Program.cs
@@ -15,6 +15,7 @@ public class Program
             while (loggedInUser == null)
             {
                 DisplayAsciiArt.Standby();
+                DisplayAsciiArt.OpeningLogo();
 
                 int selection = Menu.Start(menuText, menuOptions);
                 switch (selection)


### PR DESCRIPTION
A null reference would occur because if you went from Current Movies to Seat Selection it was possible a Theater was not yet created for that specific showing. This is now fixed, and a Theater gets created at the same time as the Showing itself. Also added another null check to be extra safe.